### PR TITLE
feat: ボーン表示改善・ポーズプレビュー再設計・ランニングマン判定修正

### DIFF
--- a/src/components/game/GameScene.jsx
+++ b/src/components/game/GameScene.jsx
@@ -125,7 +125,7 @@ function isSalutePose(lm) {
   return rightWristNearEye && rightElbowRaised && leftArmDown;
 }
 
-/** ランニングマン（ボルトポーズ） — 両腕を右上に向け、右腕を伸ばし左肘を曲げる */
+/** ランニングマン — 片腕を斜め上に伸ばし、もう片腕を下に曲げる */
 function isRunningManPose(lm) {
   if (
     !lm?.[11] ||
@@ -144,32 +144,25 @@ function isRunningManPose(lm) {
   const leftWrist = lm[15],
     rightWrist = lm[16];
 
-  // 両腕が同じ方向（右上）を向いている: 両手首が体の中心より同じ側にある
-  const shoulderCenterX = (leftShoulder.x + rightShoulder.x) / 2;
-  const bothArmsToOneSide =
-    (leftWrist.x < shoulderCenterX && rightWrist.x < shoulderCenterX) ||
-    (leftWrist.x > shoulderCenterX && rightWrist.x > shoulderCenterX);
-
-  // 両手首が肩より上にある
   const shoulderY = (leftShoulder.y + rightShoulder.y) / 2;
-  const bothWristsRaised =
-    leftWrist.y < shoulderY + 0.05 && rightWrist.y < shoulderY + 0.05;
 
-  // 片方の肘が曲がっている（手首と肩の距離が短い ≒ 肘が曲がっている）
-  const leftArmBent =
-    Math.abs(leftWrist.x - leftShoulder.x) < 0.15 &&
+  // パターン A: 右腕が上、左腕が下
+  const rightArmUp =
+    rightWrist.y < shoulderY - 0.05 &&       // 手首が肩より上
+    rightElbow.y < rightShoulder.y + 0.05;    // 肘も肩より上
+  const leftArmDown =
+    leftWrist.y > leftShoulder.y + 0.05 &&    // 手首が肩より下
+    leftElbow.y > leftShoulder.y - 0.05;      // 肘が肩付近～下
+
+  // パターン B: 左腕が上、右腕が下（逆パターン）
+  const leftArmUp =
+    leftWrist.y < shoulderY - 0.05 &&
     leftElbow.y < leftShoulder.y + 0.05;
-  const rightArmExtended = Math.abs(rightWrist.x - rightShoulder.x) > 0.1;
-  // または逆パターン
-  const rightArmBent =
-    Math.abs(rightWrist.x - rightShoulder.x) < 0.15 &&
-    rightElbow.y < rightShoulder.y + 0.05;
-  const leftArmExtended = Math.abs(leftWrist.x - leftShoulder.x) > 0.1;
+  const rightArmDown =
+    rightWrist.y > rightShoulder.y + 0.05 &&
+    rightElbow.y > rightShoulder.y - 0.05;
 
-  const boltPose =
-    (leftArmBent && rightArmExtended) || (rightArmBent && leftArmExtended);
-
-  return bothArmsToOneSide && bothWristsRaised && boltPose;
+  return (rightArmUp && leftArmDown) || (leftArmUp && rightArmDown);
 }
 
 /** ポーズIDに応じた判定関数のディスパッチ */

--- a/src/components/game/HUD.jsx
+++ b/src/components/game/HUD.jsx
@@ -96,69 +96,83 @@ export default function HUD({
 function TargetPosePreview({ poseId, active }) {
   const stroke = active ? '#44ff88' : '#8bdcff'
 
-  // 共通パーツ: 頭・体幹
-  const head = <circle cx="48" cy="18" r="9" fill="none" stroke={stroke} strokeWidth="4" />
-  const torso = <path d="M48 27 L48 50" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+  // 共通パーツ: 頭・首・肩ライン・脇腹(台形)・腰ライン・脚(膝関節付き)
+  const head = <circle cx="48" cy="14" r="9" fill="none" stroke={stroke} strokeWidth="4" />
+  // 首
+  const neck = <path d="M48 23 L48 28" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+  // 肩ライン（左肩32 ～ 右肩64）
+  const shoulders = <path d="M32 28 L64 28" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+  // 胴体: 脇腹ライン（肩→腰、中心線なし）
+  const torso = (
+    <>
+      <path d="M32 28 L38 76" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+      <path d="M64 28 L58 76" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+    </>
+  )
+  // 腰ライン（左腰38 ～ 右腰58）
+  const hips = <path d="M38 76 L58 76" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+  // 脚（膝関節付き: 腰→膝→足）
+  const legs = (
+    <>
+      <path d="M38 76 L30 96" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+      <path d="M30 96 L26 122" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+      <path d="M58 76 L66 96" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+      <path d="M66 96 L70 122" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+    </>
+  )
 
   switch (poseId) {
     // ── 両手を頭の後ろ ──
     case 'hands-behind-head':
       return (
-        <svg width="96" height="96" viewBox="0 0 96 96" aria-hidden="true">
-          {head}{torso}
-          <path d="M48 34 L31 32" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M48 34 L65 32" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M31 32 Q38 24 43 22" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M65 32 Q58 24 53 22" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M43 24 L47 26" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" opacity="0.7" />
-          <path d="M53 24 L49 26" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" opacity="0.7" />
-          <path d="M48 50 L38 72" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M48 50 L58 72" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+        <svg width="96" height="140" viewBox="0 0 96 140" aria-hidden="true">
+          {head}{neck}{shoulders}{torso}{hips}{legs}
+          {/* 左腕: 肩→肘→頭後ろ */}
+          <path d="M32 28 L20 20" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+          <path d="M20 20 Q32 10 42 14" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+          {/* 右腕: 肩→肘→頭後ろ */}
+          <path d="M64 28 L76 20" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+          <path d="M76 20 Q64 10 54 14" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+          {/* 手(後頭部) */}
+          <path d="M42 14 L46 16" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" opacity="0.7" />
+          <path d="M54 14 L50 16" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" opacity="0.7" />
         </svg>
       )
 
     // ── 両手を挙げる ──
     case 'hands-up':
       return (
-        <svg width="96" height="96" viewBox="0 0 96 96" aria-hidden="true">
-          {head}{torso}
-          {/* 両腕を真上に */}
-          <path d="M48 34 L36 28 L32 8" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M48 34 L60 28 L64 8" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          {/* 脚 */}
-          <path d="M48 50 L38 72" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M48 50 L58 72" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+        <svg width="96" height="140" viewBox="0 0 96 140" aria-hidden="true">
+          {head}{neck}{shoulders}{torso}{hips}{legs}
+          {/* 左腕: 肩→肘→上 */}
+          <path d="M32 28 L22 16 L16 2" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+          {/* 右腕: 肩→肘→上 */}
+          <path d="M64 28 L74 16 L80 2" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
         </svg>
       )
 
     // ── 敬礼 ──
     case 'salute':
       return (
-        <svg width="96" height="96" viewBox="0 0 96 96" aria-hidden="true">
-          {head}{torso}
-          {/* 右手: 額に当てる敬礼 */}
-          <path d="M48 34 L60 30 L56 16" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          {/* 左手: 体の横に下ろす */}
-          <path d="M48 34 L34 42 L30 56" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          {/* 脚 */}
-          <path d="M48 50 L42 72" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M48 50 L54 72" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+        <svg width="96" height="140" viewBox="0 0 96 140" aria-hidden="true">
+          {head}{neck}{shoulders}{torso}{hips}{legs}
+          {/* 右手: 肩→肘→額に当てる敬礼 */}
+          <path d="M64 28 L76 20 L58 10" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+          {/* 左手: 肩→肘→体の横に下ろす */}
+          <path d="M32 28 L20 46 L16 72" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
         </svg>
       )
 
     // ── ランニングマン ──
     case 'running-man':
       return (
-        <svg width="96" height="96" viewBox="0 0 96 96" aria-hidden="true">
-          {head}{torso}
-          {/* 右腕: 右上に伸ばす（一直線） */}
-          <path d="M48 34 L62 26 L76 14" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          {/* 曲げる腕: 肩から左下へ、肘で折り返して右上へ */}
-          <path d="M48 34 L38 44" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M38 44 L52 32" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          {/* 脚 */}
-          <path d="M48 50 L38 72" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
-          <path d="M48 50 L58 72" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+        <svg width="96" height="140" viewBox="0 0 96 140" aria-hidden="true">
+          {head}{neck}{shoulders}{torso}{hips}{legs}
+          {/* 右腕: 肩→肘→右上に伸ばす */}
+          <path d="M64 28 L78 16 L90 4" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+          {/* 左腕: 肩→肘（左下）→前腕（折り返し） */}
+          <path d="M32 28 L18 44" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
+          <path d="M18 44 L36 28" fill="none" stroke={stroke} strokeWidth="4" strokeLinecap="round" />
         </svg>
       )
 

--- a/src/hooks/usePersonPoseAndSegmentation.ts
+++ b/src/hooks/usePersonPoseAndSegmentation.ts
@@ -162,8 +162,8 @@ export function usePersonPoseAndSegmentation() {
                 [9,10]                                       // 口
               ]
               
-              ctx.strokeStyle = 'white'
-              ctx.lineWidth = 2
+              ctx.strokeStyle = 'cyan'
+              ctx.lineWidth = 10
               ctx.beginPath()
               connections.forEach(([i, j]) => {
                 if (lm[i] && lm[j]) {


### PR DESCRIPTION
feat: ボーン表示とポーズプレビューを改善

- カメラ入力画面のボーンを太く（lineWidth: 10）水色（cyan）に変更
- HUDのターゲットポーズプレビューをカメラのボーン構造に合わせて再設計
  - 肩幅・腰・首・膝関節を追加し人体らしい体型に
  - 胴体の中心線を削除し台形の輪郭に変更
- ランニングマンのポーズ判定をプレビュー表示に合わせて修正
  - 旧: ボルトポーズ（両腕同方向）
  - 新: 片腕を上に伸ばし、もう片腕を下に曲げる
